### PR TITLE
Bugfix: cannot start http server

### DIFF
--- a/citrus-remote-maven-plugin/src/main/resources/assemblies/test-jar.xml
+++ b/citrus-remote-maven-plugin/src/main/resources/assemblies/test-jar.xml
@@ -30,4 +30,9 @@
       <scope>test</scope>
     </dependencySet>
   </dependencySets>
+  <containerDescriptorHandlers>
+    <containerDescriptorHandler>
+      <handlerName>metaInf-spring</handlerName>
+    </containerDescriptorHandler>
+  </containerDescriptorHandlers>
 </assembly>

--- a/citrus-remote-maven-plugin/src/main/resources/assemblies/test-war.xml
+++ b/citrus-remote-maven-plugin/src/main/resources/assemblies/test-war.xml
@@ -44,4 +44,9 @@
       </includes>
     </fileSet>
   </fileSets>
+  <containerDescriptorHandlers>
+    <containerDescriptorHandler>
+      <handlerName>metaInf-spring</handlerName>
+    </containerDescriptorHandler>
+  </containerDescriptorHandlers>
 </assembly>

--- a/citrus-remote-sample/pom.xml
+++ b/citrus-remote-sample/pom.xml
@@ -27,6 +27,7 @@
         <citrus.remote.verify.phase>none</citrus.remote.verify.phase>
 
         <docker.build.phase>none</docker.build.phase>
+        <docker.copy.phase>none</docker.copy.phase>
         <docker.remove.phase>none</docker.remove.phase>
         <docker.start.phase>none</docker.start.phase>
         <docker.stop.phase>none</docker.stop.phase>
@@ -175,7 +176,7 @@
                         <goals>
                             <goal>copy</goal>
                         </goals>
-                        <phase>${citrus.remote.phase}</phase>
+                        <phase>${docker.copy.phase}</phase>
                     </execution>
                     <execution>
                         <id>stop-container</id>
@@ -311,6 +312,7 @@
                 <citrus.remote.verify.phase>verify</citrus.remote.verify.phase>
 
                 <docker.build.phase>pre-integration-test</docker.build.phase>
+                <docker.copy.phase>post-integration-test</docker.copy.phase>
                 <docker.remove.phase>post-integration-test</docker.remove.phase>
                 <docker.start.phase>pre-integration-test</docker.start.phase>
                 <docker.stop.phase>post-integration-test</docker.stop.phase>
@@ -323,6 +325,8 @@
             <properties>
                 <citrus.remote.test.phase>none</citrus.remote.test.phase>
                 <citrus.remote.verify.phase>none</citrus.remote.verify.phase>
+
+                <docker.copy.phase>none</docker.copy.phase>
             </properties>
         </profile>
         <profile>

--- a/citrus-remote-sample/pom.xml
+++ b/citrus-remote-sample/pom.xml
@@ -22,7 +22,9 @@
         <spring.version>6.1.12</spring.version>
 
         <!-- Project setup -->
-        <citrus.remote.phase>none</citrus.remote.phase>
+        <citrus.remote.report.directory>citrus-remote</citrus.remote.report.directory>
+        <citrus.remote.test.phase>none</citrus.remote.test.phase>
+        <citrus.remote.verify.phase>none</citrus.remote.verify.phase>
 
         <docker.build.phase>none</docker.build.phase>
         <docker.remove.phase>none</docker.remove.phase>
@@ -56,34 +58,6 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <assembly>
-                                <descriptor>
-                                    <inline>
-                                        <id>citrus-tests</id>
-                                        <formats>
-                                            <format>jar</format>
-                                        </formats>
-                                        <includeBaseDirectory>false</includeBaseDirectory>
-                                        <dependencySets>
-                                            <dependencySet>
-                                                <outputDirectory>/</outputDirectory>
-                                                <useProjectArtifact>false</useProjectArtifact>
-                                                <useProjectAttachments>true</useProjectAttachments>
-                                                <unpack>true</unpack>
-                                                <scope>test</scope>
-                                            </dependencySet>
-                                        </dependencySets>
-                                        <!-- Workaround for -->
-                                        <!-- https://github.com/citrusframework/citrus-remote/issues/2 -->
-                                        <!-- if the issue is fixed, the whole descriptor-section can be removed. -->
-                                        <containerDescriptorHandlers>
-                                            <containerDescriptorHandler>
-                                                <handlerName>metaInf-spring</handlerName>
-                                            </containerDescriptorHandler>
-                                        </containerDescriptorHandlers>
-                                    </inline>
-                                </descriptor>
-                            </assembly>
                             <mainClass>org.citrusframework.remote.sample.entrypoint.CustomEntrypoint</mainClass>
                         </configuration>
                     </execution>
@@ -91,9 +65,8 @@
                         <id>trigger-citrus-remote</id>
                         <goals>
                             <goal>test</goal>
-                            <goal>verify</goal>
                         </goals>
-                        <phase>${citrus.remote.phase}</phase>
+                        <phase>${citrus.remote.test.phase}</phase>
                         <configuration>
                             <server>
                                 <url>http://localhost:4567</url>
@@ -104,7 +77,19 @@
                                 <pollingInterval>15000</pollingInterval>
                             </run>
                             <report>
-                                <directory>citrus-remote</directory>
+                                <directory>${citrus.remote.report.directory}</directory>
+                            </report>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>verify-citrus-remote-tests</id>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                        <phase>${citrus.remote.verify.phase}</phase>
+                        <configuration>
+                            <report>
+                                <directory>${citrus.remote.report.directory}</directory>
                             </report>
                         </configuration>
                     </execution>
@@ -322,7 +307,8 @@
         <profile>
             <id>docker</id>
             <properties>
-                <citrus.remote.phase>integration-test</citrus.remote.phase>
+                <citrus.remote.test.phase>integration-test</citrus.remote.test.phase>
+                <citrus.remote.verify.phase>verify</citrus.remote.verify.phase>
 
                 <docker.build.phase>pre-integration-test</docker.build.phase>
                 <docker.remove.phase>post-integration-test</docker.remove.phase>
@@ -335,7 +321,8 @@
         <profile>
             <id>skip-citrus-remote</id>
             <properties>
-                <citrus.remote.phase>none</citrus.remote.phase>
+                <citrus.remote.test.phase>none</citrus.remote.test.phase>
+                <citrus.remote.verify.phase>none</citrus.remote.verify.phase>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
Resolves #2.

Add container descriptor handler for spring boot's meta inf.

The server cannot be started because the spring `NamespaceHandler` cannot be found. Adding the container descriptor handler resolves the issue.

This is the workaround mentioned in https://github.com/citrusframework/citrus-remote/issues/2#issuecomment-1642491118, moved to the default descriptors.