### PR TITLE
Version Upgrades

### DIFF
--- a/citrus-remote-maven-plugin/pom.xml
+++ b/citrus-remote-maven-plugin/pom.xml
@@ -87,10 +87,10 @@
     </dependency>
 
     <dependency>
-      <groupId>org.sonatype.plexus</groupId>
+      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-sec-dispatcher</artifactId>
       <scope>provided</scope>
-      <version>1.4</version>
+      <version>4.1.0</version>
     </dependency>
 
     <dependency>
@@ -103,7 +103,7 @@
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
       <scope>provided</scope>
-      <version>4.0.1</version>
+      <version>4.0.2</version>
     </dependency>
 
     <dependency>
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-interactivity-api</artifactId>
-      <version>1.0-alpha-6</version>
+      <version>1.4</version>
     </dependency>
 
     <!-- Logging -->

--- a/citrus-remote-sample/pom.xml
+++ b/citrus-remote-sample/pom.xml
@@ -19,8 +19,8 @@
         <download-maven-plugin.version>1.9.0</download-maven-plugin.version>
 
         <!-- Dependency versions -->
-        <citrus.version>4.5.2</citrus.version>
-        <spring.version>6.2.2</spring.version>
+        <citrus.version>4.6.0</citrus.version>
+        <spring.version>6.2.6</spring.version>
 
         <!-- Project setup -->
         <citrus.remote.report.directory>citrus-remote</citrus.remote.report.directory>

--- a/citrus-remote-server/src/main/java/org/citrusframework/remote/listener/RemoteTestListener.java
+++ b/citrus-remote-server/src/main/java/org/citrusframework/remote/listener/RemoteTestListener.java
@@ -65,7 +65,7 @@ public class RemoteTestListener implements TestListener {
     }
 
     @Override
-    public void onTestFinish(TestCase test) {
+    public void onTestExecutionEnd(TestCase test) {
         // NOOP
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <java.version>17</java.version>
 
     <maven.version>3.9.8</maven.version>
-    <maven.compiler.version>3.11.0</maven.compiler.version>
+    <maven.compiler.version>3.14.0</maven.compiler.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -31,7 +31,7 @@
     <maven.clean.plugin.version>3.3.1</maven.clean.plugin.version>
     <maven.dependency.plugin.version>3.8.1</maven.dependency.plugin.version>
     <maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
-    <maven.failsafe.plugin.version>2.22.2</maven.failsafe.plugin.version>
+    <maven.failsafe.plugin.version>3.5.3</maven.failsafe.plugin.version>
     <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
     <maven.helper.plugin.version>3.6.0</maven.helper.plugin.version>
     <maven.install.plugin.version>3.1.1</maven.install.plugin.version>
@@ -44,17 +44,17 @@
     <maven.resource.plugin.version>3.3.1</maven.resource.plugin.version>
     <maven.scm.plugin.version>1.11.2</maven.scm.plugin.version>
     <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
-    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+    <maven.surefire.plugin.version>3.5.3</maven.surefire.plugin.version>
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
     <apache.rat.plugin.version>0.16.1</apache.rat.plugin.version>
 
-    <citrus.version>4.5.2</citrus.version>
     <commons.logging.api.version>1.1</commons.logging.api.version>
-    <commons.logging.version>1.3.4</commons.logging.version>
-    <httpclient.version>5.4.1</httpclient.version>
-    <jackson.version>2.18.2</jackson.version>
+    <citrus.version>4.6.0</citrus.version>
+    <commons.logging.version>1.3.5</commons.logging.version>
+    <httpclient.version>5.4.4</httpclient.version>
+    <jackson.version>2.18.3</jackson.version>
     <log4j2.version>2.23.1</log4j2.version>
-    <slf4j.version>2.0.11</slf4j.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <vertx.version>4.5.11</vertx.version>
     <xstream.version>1.4.21</xstream.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
     <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
     <apache.rat.plugin.version>0.16.1</apache.rat.plugin.version>
 
-    <commons.logging.api.version>1.1</commons.logging.api.version>
     <citrus.version>4.6.0</citrus.version>
     <commons.logging.version>1.3.5</commons.logging.version>
     <httpclient.version>5.4.4</httpclient.version>
@@ -198,11 +197,6 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j2-impl</artifactId>
         <version>${log4j2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-logging</groupId>
-        <artifactId>commons-logging-api</artifactId>
-        <version>${commons.logging.api.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>


### PR DESCRIPTION
- compiler-plugin from 3.11.0 to 3.14.0
- surefire and failsafe from 2.22.2 to 3.5.3
- citrus from 4.5.2 to 4.6.0
- commons.logging from 1.3.4 to 1.3.5
- httpclient from 5.4.1 to 5.4.4
- jackson from 2.18.2 to 2.18.3
- slf4j from 2.0.11 to 2.0.17
- plexus-sec-dispatcher from 1.4 to 4.1.0
- plexus-utils from 4.0.1 to 4.0.2
- plexus-interactivity-api from 1.0-alpha-6 to 1.4
- spring form 6.2.2 to 6.2.6

Remove unused dependency commons-logging-api.

`RemoteTestListener`: Instead of overriding deprecated `onTestFinish(...)`, override `onTestExecutionEnd(...)`